### PR TITLE
Compatibility with XYZ

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DCD"
 uuid = "cc05301c-b019-4863-b507-407516a92140"
 authors = ["Axel Gomez"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"


### PR DESCRIPTION
For compatibility, the DCD objects cannot have the same type as similar XYZ objects with the same method/functions. I rename File as FileDCD and Frame as FrameDCD.